### PR TITLE
Fix log LogIniter and change config g_logger to use SYLAR_LOG_ROOT

### DIFF
--- a/sylar/config.cc
+++ b/sylar/config.cc
@@ -13,7 +13,7 @@
 
 namespace sylar {
 
-static sylar::Logger::ptr g_logger = SYLAR_LOG_NAME("system");
+static sylar::Logger::ptr g_logger = SYLAR_LOG_ROOT();
 
 ConfigVarBase::ptr Config::LookupBase(const std::string &name) {
     RWMutexType::ReadLock lock(GetMutex());

--- a/sylar/log.cpp
+++ b/sylar/log.cpp
@@ -702,7 +702,7 @@ struct LogIniter {
                 } else {
                     if(!(i == *it)) {
                         // 修改的logger
-                        logger == SYLAR_LOG_NAME(i.name);
+                        logger = SYLAR_LOG_NAME(i.name);
                     } else {
                         continue;
                     }


### PR DESCRIPTION
修复了log.cpp文件下LogIniter回调函数中，对需要修改配置的logger赋值写为“==”的小bug。
将config.cc文件中 g_logger 修改为使用SYLAR_LOG_ROOT，从而修复加载配置文件时没有正确输出的小bug。