### PR TITLE
Add a lock to StdoutLogAppender log

### DIFF
--- a/sylar/log.cpp
+++ b/sylar/log.cpp
@@ -398,6 +398,7 @@ StdoutLogAppender::StdoutLogAppender()
 }
 
 void StdoutLogAppender::log(LogEvent::ptr event) {
+    MutexType::Lock lock(m_mutex);
     if(m_formatter) {
         m_formatter->format(std::cout, event);
     } else {


### PR DESCRIPTION
给StdoutLogAppender的log函数添加了锁，确保执行多线程任务时日志信息输出到终端不会混乱